### PR TITLE
Fix picking a null property with a dotted value.

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ DotObject.prototype.pick = function(path, obj, remove) {
   if (path.indexOf(this.seperator) !== -1) {
     keys = path.split(this.seperator);
     for (i = 0; i < keys.length; i++) {
-      if (obj && obj.hasOwnProperty(keys[i])) {
+      if (obj && typeof obj === 'object' && keys[i] in obj) {
         if (i === (keys.length - 1)) {
           if (remove) {
             val = obj[keys[i]];

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ DotObject.prototype.pick = function(path, obj, remove) {
   if (path.indexOf(this.seperator) !== -1) {
     keys = path.split(this.seperator);
     for (i = 0; i < keys.length; i++) {
-      if (obj.hasOwnProperty(keys[i])) {
+      if (obj && obj.hasOwnProperty(keys[i])) {
         if (i === (keys.length - 1)) {
           if (remove) {
             val = obj[keys[i]];

--- a/test/pick.js
+++ b/test/pick.js
@@ -36,4 +36,46 @@ describe('DJ value picker:', function() {
 
   });
 
+  it('Should be able to pick null properties', function() {
+
+    var dj = new DJ();
+
+    var obj = {
+      'some': null
+    };
+
+    var val = dj.pick('some', obj);
+
+    (val === null).should.be.true;
+
+  });
+
+  it('Should return undefined when picking an non-existing value', function() {
+
+    var dj = new DJ();
+
+    var obj = {
+      'some': null
+    };
+
+    var val = dj.pick('other', obj);
+
+    (val === undefined).should.be.true;
+
+  });
+
+  it('Should return undefined when picking an non-existing dotted value', function() {
+
+    var dj = new DJ();
+
+    var obj = {
+      'some': null
+    };
+
+    var val = dj.pick('some.other', obj);
+
+    (val === undefined).should.be.true;
+
+  });
+
 });

--- a/test/pick.js
+++ b/test/pick.js
@@ -78,4 +78,23 @@ describe('DJ value picker:', function() {
 
   });
 
+  it('Should check down the object\'s prototype chain', function() {
+
+    var dj = new DJ();
+
+    var obj = {
+      'some': {
+        'other': 'value'
+      }
+    };
+
+    var objIns = Object.create(obj);    
+
+    objIns.should.have.property('some');
+
+    var val = dj.pick('some.other', objIns);
+    val.should.be.an.Object;
+
+  });
+
 });


### PR DESCRIPTION
Just fixed a bug that happened while trying to pick a null property using the dotted notation value.

Also, I have removed hasOwnProperty() from pick.js, as properties are sometimes inherited (I'm using Mongoose ODM, thats why I figured that out).

I wrote 4 extra tests, being the third ("'Should return undefined when picking an non-existing dotted value'") the one that failed, and the fourth ("Should check down the object\'s prototype chain") the one for the prototype chain.