### PR TITLE
Adds a parameter (useArray) to allow converting object without using arrays.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,24 +42,24 @@ function parsePath(path, sep) {
   return path.split(sep);
 }
 
-function DotObject(seperator, override, useIndex) {
+function DotObject(seperator, override, useArray) {
 
   if (!(this instanceof DotObject)) {
-    return new DotObject(seperator, override, useIndex);
+    return new DotObject(seperator, override, useArray);
   }
 
   if (typeof seperator === 'undefined') { seperator = '.'; }
   if (typeof override === 'undefined') { override = false; }
-  if (typeof useIndex === 'undefined') { useIndex = true; }
+  if (typeof useArray === 'undefined') { useArray = true; }
   this.seperator = seperator;
   this.override = override;
-  this.useIndex = useIndex;
+  this.useArray = useArray;
 
   // contains touched arrays
   this.cleanup = [];
 }
 
-var dotDefault = new DotObject('.', false);
+var dotDefault = new DotObject('.', false, true);
 function wrap(method) {
   return function() {
     return dotDefault[method].apply(dotDefault, arguments);
@@ -70,7 +70,8 @@ DotObject.prototype._fill = function(a, obj, v, mod) {
   var k = a.shift();
 
   if (a.length > 0) {
-    obj[k] = obj[k] || (a.length === 1 && isIndex(a[0], this.useIndex) ? [] : {});
+    obj[k] = obj[k] ||
+      (a.length === 1 && isIndex(a[0], this.useArray) ? [] : {});
 
     if (obj[k] !== Object(obj[k])) {
       if (this.override) {
@@ -219,8 +220,6 @@ DotObject.prototype.remove = function(path, obj) {
   } else {
     return this.pick(path, obj, true);
   }
-  //should return a value. Important for gulp tests. Failure if not present, even if the execution never go there.
-  return;
 };
 
 DotObject.prototype._cleanup = function(obj) {
@@ -444,6 +443,15 @@ DotObject.dot = wrap('dot');
       dotDefault.override = !!val;
     }
   });
+});
+
+Object.defineProperty(DotObject, 'useArray', {
+  get: function() {
+    return dotDefault.useArray;
+  },
+  set: function(val) {
+    dotDefault.useArray = val;
+  }
 });
 
 DotObject._process = _process;

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function parseKey(key, val) {
 }
 
 function isIndex(k) {
-  return /^\d+/.test(k);
+  return useIndex && /^\d+/.test(k);
 }
 
 function parsePath(path, sep) {
@@ -45,13 +45,15 @@ function parsePath(path, sep) {
 function DotObject(seperator, override) {
 
   if (!(this instanceof DotObject)) {
-    return new DotObject(seperator, override);
+    return new DotObject(seperator, override, useIndex);
   }
 
   if (typeof seperator === 'undefined') { seperator = '.'; }
   if (typeof override === 'undefined') { override = false; }
+  if (typeof useIndex === 'undefined') { override = true; }
   this.seperator = seperator;
   this.override = override;
+  this.useIndex = useIndex;
 
   // contains touched arrays
   this.cleanup = [];

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function parseKey(key, val) {
   return key;
 }
 
-function isIndex(k) {
+function isIndex(k, useIndex) {
   return useIndex && /^\d+/.test(k);
 }
 
@@ -42,15 +42,15 @@ function parsePath(path, sep) {
   return path.split(sep);
 }
 
-function DotObject(seperator, override) {
+function DotObject(seperator, override, useIndex) {
 
   if (!(this instanceof DotObject)) {
-    return new DotObject(seperator, override, useIndex);
+    return new DotObject(seperator, override, true);
   }
 
   if (typeof seperator === 'undefined') { seperator = '.'; }
   if (typeof override === 'undefined') { override = false; }
-  if (typeof useIndex === 'undefined') { override = true; }
+  if (typeof useIndex === 'undefined') { useIndex = true; }
   this.seperator = seperator;
   this.override = override;
   this.useIndex = useIndex;
@@ -70,7 +70,7 @@ DotObject.prototype._fill = function(a, obj, v, mod) {
   var k = a.shift();
 
   if (a.length > 0) {
-    obj[k] = obj[k] || (a.length === 1 && isIndex(a[0]) ? [] : {});
+    obj[k] = obj[k] || (a.length === 1 && isIndex(a[0], this.useIndex) ? [] : {});
 
     if (obj[k] !== Object(obj[k])) {
       if (this.override) {
@@ -219,6 +219,8 @@ DotObject.prototype.remove = function(path, obj) {
   } else {
     return this.pick(path, obj, true);
   }
+  //should return a value. Important for gulp tests. Failure if not present, even if the execution never go there.
+  return;
 };
 
 DotObject.prototype._cleanup = function(obj) {

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function parsePath(path, sep) {
 function DotObject(seperator, override, useIndex) {
 
   if (!(this instanceof DotObject)) {
-    return new DotObject(seperator, override, true);
+    return new DotObject(seperator, override, useIndex);
   }
 
   if (typeof seperator === 'undefined') { seperator = '.'; }

--- a/src/dot-object.js
+++ b/src/dot-object.js
@@ -42,24 +42,24 @@ function parsePath(path, sep) {
   return path.split(sep);
 }
 
-function DotObject(seperator, override, useIndex) {
+function DotObject(seperator, override, useArray) {
 
   if (!(this instanceof DotObject)) {
-    return new DotObject(seperator, override, useIndex);
+    return new DotObject(seperator, override, useArray);
   }
 
   if (typeof seperator === 'undefined') { seperator = '.'; }
   if (typeof override === 'undefined') { override = false; }
-  if (typeof useIndex === 'undefined') { useIndex = true; }
+  if (typeof useArray === 'undefined') { useArray = true; }
   this.seperator = seperator;
   this.override = override;
-  this.useIndex = useIndex;
+  this.useArray = useArray;
 
   // contains touched arrays
   this.cleanup = [];
 }
 
-var dotDefault = new DotObject('.', false);
+var dotDefault = new DotObject('.', false, true);
 function wrap(method) {
   return function() {
     return dotDefault[method].apply(dotDefault, arguments);
@@ -70,7 +70,8 @@ DotObject.prototype._fill = function(a, obj, v, mod) {
   var k = a.shift();
 
   if (a.length > 0) {
-    obj[k] = obj[k] || (a.length === 1 && isIndex(a[0], this.useIndex) ? [] : {});
+    obj[k] = obj[k] ||
+      (a.length === 1 && isIndex(a[0], this.useArray) ? [] : {});
 
     if (obj[k] !== Object(obj[k])) {
       if (this.override) {
@@ -219,8 +220,6 @@ DotObject.prototype.remove = function(path, obj) {
   } else {
     return this.pick(path, obj, true);
   }
-  //should return a value. Important for gulp tests. Failure if not present, even if the execution never go there.
-  return;
 };
 
 DotObject.prototype._cleanup = function(obj) {
@@ -444,6 +443,15 @@ DotObject.dot = wrap('dot');
       dotDefault.override = !!val;
     }
   });
+});
+
+Object.defineProperty(DotObject, 'useArray', {
+  get: function() {
+    return dotDefault.useArray;
+  },
+  set: function(val) {
+    dotDefault.useArray = val;
+  }
 });
 
 DotObject._process = _process;

--- a/src/dot-object.js
+++ b/src/dot-object.js
@@ -30,7 +30,7 @@ function parseKey(key, val) {
 }
 
 function isIndex(k) {
-  return /^\d+/.test(k);
+  return useIndex && /^\d+/.test(k);
 }
 
 function parsePath(path, sep) {
@@ -45,13 +45,15 @@ function parsePath(path, sep) {
 function DotObject(seperator, override) {
 
   if (!(this instanceof DotObject)) {
-    return new DotObject(seperator, override);
+    return new DotObject(seperator, override, useIndex);
   }
 
   if (typeof seperator === 'undefined') { seperator = '.'; }
   if (typeof override === 'undefined') { override = false; }
+  if (typeof useIndex === 'undefined') { override = true; }
   this.seperator = seperator;
   this.override = override;
+  this.useIndex = useIndex;
 
   // contains touched arrays
   this.cleanup = [];

--- a/src/dot-object.js
+++ b/src/dot-object.js
@@ -29,7 +29,7 @@ function parseKey(key, val) {
   return key;
 }
 
-function isIndex(k) {
+function isIndex(k, useIndex) {
   return useIndex && /^\d+/.test(k);
 }
 
@@ -42,15 +42,15 @@ function parsePath(path, sep) {
   return path.split(sep);
 }
 
-function DotObject(seperator, override) {
+function DotObject(seperator, override, useIndex) {
 
   if (!(this instanceof DotObject)) {
-    return new DotObject(seperator, override, useIndex);
+    return new DotObject(seperator, override, true);
   }
 
   if (typeof seperator === 'undefined') { seperator = '.'; }
   if (typeof override === 'undefined') { override = false; }
-  if (typeof useIndex === 'undefined') { override = true; }
+  if (typeof useIndex === 'undefined') { useIndex = true; }
   this.seperator = seperator;
   this.override = override;
   this.useIndex = useIndex;
@@ -70,7 +70,7 @@ DotObject.prototype._fill = function(a, obj, v, mod) {
   var k = a.shift();
 
   if (a.length > 0) {
-    obj[k] = obj[k] || (a.length === 1 && isIndex(a[0]) ? [] : {});
+    obj[k] = obj[k] || (a.length === 1 && isIndex(a[0], this.useIndex) ? [] : {});
 
     if (obj[k] !== Object(obj[k])) {
       if (this.override) {
@@ -219,6 +219,8 @@ DotObject.prototype.remove = function(path, obj) {
   } else {
     return this.pick(path, obj, true);
   }
+  //should return a value. Important for gulp tests. Failure if not present, even if the execution never go there.
+  return;
 };
 
 DotObject.prototype._cleanup = function(obj) {

--- a/src/dot-object.js
+++ b/src/dot-object.js
@@ -45,7 +45,7 @@ function parsePath(path, sep) {
 function DotObject(seperator, override, useIndex) {
 
   if (!(this instanceof DotObject)) {
-    return new DotObject(seperator, override, true);
+    return new DotObject(seperator, override, useIndex);
   }
 
   if (typeof seperator === 'undefined') { seperator = '.'; }

--- a/test/useArray.js
+++ b/test/useArray.js
@@ -1,0 +1,72 @@
+'use strict';
+
+require('should');
+var Dot = require('../index');
+
+describe('useArray:', function () {
+
+  var dotObject, arrayObject, object;
+  var arrayObjectExpected, objectExpected, dotObjectExpected;
+
+  beforeEach(function () {
+
+    dotObject = {
+      'a.0': 'value'
+    };
+    dotObjectExpected = {
+      'a.0': 'value'
+    };
+    arrayObject = {
+      a: ['value']
+    };
+    arrayObjectExpected = {
+      a: ['value']
+    };
+    object = {
+      a: {
+        '0': 'value'
+      }
+    };
+    objectExpected = {
+      a: {
+        '0': 'value'
+      }
+    };
+
+  });
+
+
+  it('default is using array ', function () {
+    var dotLocal = require('../index');
+    arrayObjectExpected.should.eql(dotLocal.object(dotObject));
+  });
+  it('Should convert dot using arrays ', function () {
+    Dot.useArray = true;
+    arrayObjectExpected.should.eql(Dot.object(dotObject));
+  });
+  it('Should convert dot not using arrays ', function () {
+    Dot.useArray = false;
+    objectExpected.should.eql(Dot.object(dotObject));
+  });
+  it('Should convert object using arrays ', function () {
+    Dot.useArray = true;
+    arrayObjectExpected.should.eql(Dot.object(dotObject));
+  });
+  it('Should convert dot using arrays and convert back equals source', function () {
+    Dot.useArray = true;
+    dotObjectExpected.should.eql(Dot.dot(Dot.object(dotObject)));
+  });
+  it('Should convert object using arrays and convert back equals source', function () {
+    Dot.useArray = true;
+    arrayObjectExpected.should.eql(Dot.object(Dot.dot(object)));
+  });
+  it('Should convert dot not using arrays and convert back equals source', function () {
+    Dot.useArray = false;
+    dotObjectExpected.should.eql(Dot.dot(Dot.object(dotObject)));
+  });
+  it('Should convert object not using arrays and convert back equals source', function () {
+    Dot.useArray = false;
+    objectExpected.should.eql(Dot.object(Dot.dot(arrayObject)));
+  });
+
+});


### PR DESCRIPTION
ie {'object.without.array.0':'value'} ==> {object:{without:{array:{0:'value'}}}}
and not {object:{without:{array:['value']}}} while useArray is set to false.