### PR TITLE
Add license property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "bugs": {
     "url": "https://github.com/rhalff/dot-object/issues"
   },
+  "license": "MIT",
   "main": "index",
   "bin": "./bin/dot-object",
   "scripts": {


### PR DESCRIPTION
Automated license managers like xz64/license-webpack-plugin rely on the license property in package.json to determine license type in libraries. This prevents users of dot-object from having to add an override for it.