### PR TITLE
Ignore paths that not exists

### DIFF
--- a/src/dot-object.js
+++ b/src/dot-object.js
@@ -49,6 +49,9 @@ var blacklist = ['__proto__', 'prototype', 'constructor']
 var blacklistFilter = function (part) { return blacklist.indexOf(part) === -1 }
 
 function parsePath (path, sep) {
+  if (!path) {
+    return [];
+  }
   if (path.indexOf('[') >= 0) {
     path = path.replace(/\[/g, '.').replace(/]/g, '')
   }


### PR DESCRIPTION
When using the "pick" method when making parsePath and the specified path does not exist, an error occurs where it is not possible to make the indexOf of undefined