### PR TITLE
Fix parsing of array paths for non standard separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ var blacklistFilter = function (part) { return blacklist.indexOf(part) === -1 }
 
 function parsePath (path, sep) {
   if (path.indexOf('[') >= 0) {
-    path = path.replace(/\[/g, '.').replace(/]/g, '')
+    path = path.replace(/\[/g, sep).replace(/]/g, '')
   }
 
   var parts = path.split(sep)

--- a/src/dot-object.js
+++ b/src/dot-object.js
@@ -50,7 +50,7 @@ var blacklistFilter = function (part) { return blacklist.indexOf(part) === -1 }
 
 function parsePath (path, sep) {
   if (path.indexOf('[') >= 0) {
-    path = path.replace(/\[/g, '.').replace(/]/g, '')
+    path = path.replace(/\[/g, sep).replace(/]/g, '')
   }
 
   var parts = path.split(sep)

--- a/test/dot-json.js
+++ b/test/dot-json.js
@@ -55,6 +55,28 @@ describe('Object test:', function () {
     })
   })
 
+  it('Should expand dotted keys with array notation with different separator', function () {
+    var row = {
+      id: 2,
+      my_arr_0: 'one',
+      my_arr_1: 'two',
+      my_arr_2: 'three',
+      'my_arr2[0]': 'one',
+      'my_arr2[1]': 'two',
+      'my_arr2[2]': 'three'
+    }
+
+    new Dot('_').object(row)
+
+    row.should.eql({
+      id: 2,
+      my: {
+        arr: ['one', 'two', 'three'],
+        arr2: ['one', 'two', 'three']
+      }
+    })
+  })
+
   it('Should allow keys with numbers', function () {
     var row = {
       id: 2,


### PR DESCRIPTION
Prior to the change arrays only worked with the default separator of `.`.
So the following currently has different results, even though one would expect them to behave the same:
```
var Dot = require("dot-object");

// default separator, works as expected:
console.log(Dot.object({'first.name[0]': 'first'}));
// outputs: {first: {name: ["first"]}}

// non standard separator, does not return array:
console.log(new Dot('_').object({'first_name[0]': 'first'}));
// outputs: {first: {name.0: "first"}}
```

With this fix, the second version gives the same result as the first one.