### PR TITLE
remove version in package.json for test fixture

### DIFF
--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,7 +1,6 @@
 {
   "name": "dot-object",
   "description": "dot-object makes it possible to transform and read (JSON) objects using dot notation.",
-  "version": "1.1.0",
   "author": {
     "name": "Rob Halff",
     "email": "rob.halff@gmail.com"


### PR DESCRIPTION
This version info will be found by some scan services in charge of managing vulnerabilities. 
I found some service reports CVE-2019-10793 even if fixed version is used. 

@rhalff Can you please review?